### PR TITLE
invalid escape sequence in py 3.12

### DIFF
--- a/pyasn1/type/constraint.py
+++ b/pyasn1/type/constraint.py
@@ -97,7 +97,7 @@ class AbstractConstraint(object):
 
 
 class SingleValueConstraint(AbstractConstraint):
-    """Create a SingleValueConstraint object.
+    r"""Create a SingleValueConstraint object.
 
     The SingleValueConstraint satisfies any value that
     is present in the set of permitted values.
@@ -138,7 +138,7 @@ class SingleValueConstraint(AbstractConstraint):
 
 
 class ContainedSubtypeConstraint(AbstractConstraint):
-    """Create a ContainedSubtypeConstraint object.
+    r"""Create a ContainedSubtypeConstraint object.
 
     The ContainedSubtypeConstraint satisfies any value that
     is present in the set of permitted values and also
@@ -298,7 +298,7 @@ class ValueSizeConstraint(ValueRangeConstraint):
 
 
 class PermittedAlphabetConstraint(SingleValueConstraint):
-    """Create a PermittedAlphabetConstraint object.
+    r"""Create a PermittedAlphabetConstraint object.
 
     The PermittedAlphabetConstraint satisfies any character
     string for as long as all its characters are present in
@@ -454,7 +454,7 @@ class AbstractConstraintSet(AbstractConstraint):
 
 
 class ConstraintsIntersection(AbstractConstraintSet):
-    """Create a ConstraintsIntersection logic operator object.
+    r"""Create a ConstraintsIntersection logic operator object.
 
     The ConstraintsIntersection logic operator only succeeds
     if *all* its operands succeed.
@@ -498,7 +498,7 @@ class ConstraintsIntersection(AbstractConstraintSet):
 
 
 class ConstraintsUnion(AbstractConstraintSet):
-    """Create a ConstraintsUnion logic operator object.
+    r"""Create a ConstraintsUnion logic operator object.
 
     The ConstraintsUnion logic operator only succeeds if
     *at least a single* operand succeeds.

--- a/pyasn1/type/namedval.py
+++ b/pyasn1/type/namedval.py
@@ -12,7 +12,7 @@ __all__ = ['NamedValues']
 
 
 class NamedValues(object):
-    """Create named values object.
+    r"""Create named values object.
 
     The |NamedValues| object represents a collection of string names
     associated with numeric IDs. These objects are used for giving


### PR DESCRIPTION
To fix: [b/360351332](https://b.corp.google.com/360351332)

Fix reference:
A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/dev/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/dev/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning).

python 3.12 documentation reference: [documentation](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes)